### PR TITLE
Abort if the first argument is not given

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -u
+
 EXECUTABLE="$1"
 
 cat <<EOT


### PR DESCRIPTION
IMO, we should almost always enable `-u` (and usually with `-e`) in a bash script.